### PR TITLE
Use Jekyll layout for pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Page Not Found
+permalink: /404.html
+---
+
+<section class="not-found">
+  <h1>Page not found</h1>
+  <p>The page you requested could not be found.</p>
+</section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ page.title | default: "Alden Muffin Tin" }}</title>
+  <link rel="stylesheet" href="{{ '/styles.css' | relative_url }}">
+</head>
+<body>
+  {{ content }}
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,49 +1,43 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Alden Muffin Tin</title>
-  <link rel="stylesheet" href="styles.css" />
-</head>
-<body>
-  <header>
-    <h1>Alden Muffin Tin</h1>
-    <nav>
-      <ul>
-        <li><a href="#about">About</a></li>
-        <li><a href="#products">Products</a></li>
-        <li><a href="#contact">Contact</a></li>
-      </ul>
-    </nav>
-  </header>
+---
+layout: default
+title: Alden Muffin Tin
+---
 
-  <section id="hero">
-    <h2>Fresh Muffins Every Day</h2>
-    <p>Discover our delicious muffins baked with love.</p>
-  </section>
-
-  <section id="about">
-    <h2>About Us</h2>
-    <p>Alden Muffin Tin is dedicated to delivering the best muffins in town.</p>
-  </section>
-
-  <section id="products">
-    <h2>Our Muffins</h2>
-    <ul class="product-list">
-      <li>Blueberry Bliss</li>
-      <li>Chocolate Delight</li>
-      <li>Classic Vanilla</li>
+<header>
+  <h1>Alden Muffin Tin</h1>
+  <nav>
+    <ul>
+      <li><a href="#about">About</a></li>
+      <li><a href="#products">Products</a></li>
+      <li><a href="#contact">Contact</a></li>
     </ul>
-  </section>
+  </nav>
+</header>
 
-  <section id="contact">
-    <h2>Contact</h2>
-    <p>Email us at <a href="mailto:info@aldenmuffintin.com">info@aldenmuffintin.com</a></p>
-  </section>
+<section id="hero">
+  <h2>Fresh Muffins Every Day</h2>
+  <p>Discover our delicious muffins baked with love.</p>
+</section>
 
-  <footer>
-    <p>&copy; 2024 Alden Muffin Tin. All rights reserved.</p>
-  </footer>
-</body>
-</html>
+<section id="about">
+  <h2>About Us</h2>
+  <p>Alden Muffin Tin is dedicated to delivering the best muffins in town.</p>
+</section>
+
+<section id="products">
+  <h2>Our Muffins</h2>
+  <ul class="product-list">
+    <li>Blueberry Bliss</li>
+    <li>Chocolate Delight</li>
+    <li>Classic Vanilla</li>
+  </ul>
+</section>
+
+<section id="contact">
+  <h2>Contact</h2>
+  <p>Email us at <a href="mailto:info@aldenmuffintin.com">info@aldenmuffintin.com</a></p>
+</section>
+
+<footer>
+  <p>&copy; 2024 Alden Muffin Tin. All rights reserved.</p>
+</footer>


### PR DESCRIPTION
## Summary
- convert index to use shared Jekyll layout
- add site-wide default layout referencing stylesheet
- create custom 404 page for missing routes

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npx -y htmlhint index.html 404.html _layouts/default.html` *(fails: Doctype must be declared before any non-comment content)*

------
https://chatgpt.com/codex/tasks/task_e_688f9dd925408329a8f165577f7a546a